### PR TITLE
Fix foundation compatibility issues

### DIFF
--- a/dist/css/ng-wig.css
+++ b/dist/css/ng-wig.css
@@ -52,19 +52,18 @@
   .nw-toolbar__item {
     display: inline-block;
     vertical-align: top;
-
     border-right: 1px solid #DEDEDE;
   }
 
   .nw-toolbar label {
+      font-size: inherit;
       line-height: 30px;
       display: inline-block;
       padding: 0 6px 0 3px;
   }
 
   .nw-toolbar input[type=checkbox] {
-      vertical-align: -3px;
-      margin-right: -1px;
+      margin: 0 -1px 0 0;
   }
 
 /**
@@ -101,7 +100,7 @@
  *    &--{button type}
  *
  */
-.nw-button {
+button.nw-button {
   -webkit-appearance: none;
   -moz-appearance:    none;
   appearance:         none;
@@ -121,14 +120,14 @@
 
   cursor: pointer;
 }
-  .nw-button:focus {
+  button.nw-button:focus {
       outline: none;
   }
 
-  .nw-button:hover,
-  .nw-button.nw-button--active { opacity: 1 }
+  button.nw-button:hover,
+  button.nw-button.nw-button--active { opacity: 1; }
 
-  .nw-button--active {
+  button.nw-button--active {
     background-color: #EEEEEE;
   }
   /* text formatting */


### PR DESCRIPTION
I've found some styling issues when working with foundation. Following a screenshot.
What i did:
- Fixed .nw-toolbar label and input[type=checkbox]
- Added button to .nw-button (Buttons were showing blue on hover)
  ![schermata 10-2456951 alle 11 50 44](https://cloud.githubusercontent.com/assets/1750404/4699399/4f96691e-5840-11e4-96d5-78c90d9564a3.jpg)
