### PR TITLE
Prevented mutual effects for multiple editors on one page

### DIFF
--- a/src/javascript/app/ng-wig/ngWigDirective.js
+++ b/src/javascript/app/ng-wig/ngWigDirective.js
@@ -29,7 +29,10 @@ angular.module('ngWig')
               return;
             }
           }
-          scope.$emit('execCommand', {command: command, options: options});
+
+          if(!scope.editMode ) {
+            scope.$emit('execCommand', {command: command, options: options});
+          }
         };
 
         scope.styles = [

--- a/src/javascript/app/ng-wig/views/ng-wig.html
+++ b/src/javascript/app/ng-wig/views/ng-wig.html
@@ -11,7 +11,7 @@
               ng-click="execCommand(button.command)"></button>
     </li><!--
     --><li class="nw-toolbar__item">
-      <button type="button" class="nw-button nw-button--source" ng-class="{ 'nw-button--active': editMode }" ng-click="toggleEditMode()"></button>
+      <button type="button" class="nw-button nw-button--source" ng-class="{ 'nw-button--active': editMode }" ng-click="toggleEditMode()" title="Source"></button>
     </li>
   </ul>
 


### PR DESCRIPTION
STR:
- init some ngWig editors on page
- click "Source" button in first one
- highlight part of text in second
- click "Bold" button in first
- font weight of highlighted text in second editor changed to the bold