### PR TITLE
Move font icons to styles

### DIFF
--- a/src/css/ng-wig.css
+++ b/src/css/ng-wig.css
@@ -53,6 +53,7 @@
 .nw-toolbar__item {
   display: inline-block;
   vertical-align: top;
+  margin: 0;
 
   border-right: 1px solid #DEDEDE;
 }
@@ -165,7 +166,38 @@
   border: none;
   border-radius: 2px;
 
+  font-size: 0;
+
   cursor: pointer;
+}
+
+.nw-button:before {
+  font-size: 12px;
+  font-family: FontAwesome;
+}
+
+.nw-button.bold:before {
+  content: '\f032';
+}
+
+.nw-button.italic:before {
+  content: '\f033';
+}
+
+.nw-button.list-ul:before {
+  content: '\f0ca';
+}
+
+.nw-button.list-ol:before {
+  content: '\f0cb';
+}
+
+.nw-button.link:before {
+  content: '\f0c1';
+}
+
+.nw-button.nw-button--source:before {
+  content: '\f040';
 }
 
 .nw-button:focus {

--- a/src/javascript/app/ng-wig/ngWigToolbarProvider.js
+++ b/src/javascript/app/ng-wig/ngWigToolbarProvider.js
@@ -1,11 +1,11 @@
 angular.module('ngWig').provider('ngWigToolbar', function () {
 
   var buttonLibrary = {
-    list1: {title: 'Unordered List', command: 'insertunorderedlist', styleClass: 'fa-list-ul'},
-    list2: {title: 'Ordered List', command: 'insertorderedlist', styleClass: 'fa-list-ol'},
-    bold: {title: 'Bold', command: 'bold', styleClass: 'fa-bold'},
-    italic: {title: 'Italic', command: 'italic', styleClass: 'fa-italic'},
-    link: {title: 'Link', command: 'createlink', styleClass: 'fa-link'}
+    list1: {title: 'Unordered List', command: 'insertunorderedlist', styleClass: 'list-ul'},
+    list2: {title: 'Ordered List', command: 'insertorderedlist', styleClass: 'list-ol'},
+    bold: {title: 'Bold', command: 'bold', styleClass: 'bold'},
+    italic: {title: 'Italic', command: 'italic', styleClass: 'italic'},
+    link: {title: 'Link', command: 'createlink', styleClass: 'link'}
   };
 
   var defaultButtonsList = ['list1', 'list2', 'bold', 'italic', 'link'];

--- a/src/javascript/app/ng-wig/views/ng-wig.html
+++ b/src/javascript/app/ng-wig/views/ng-wig.html
@@ -2,8 +2,8 @@
   <ul class="nw-toolbar">
     <li class="nw-toolbar__item" ng-repeat="button in toolbarButtons" >
         <div ng-if="!button.isComplex">
-          <button type="button" class="nw-button" title="{{button.title}}" ng-click="execCommand(button.command)" ng-class="{ 'nw-button--active': isEditorActive() && button.isActive() }" ng-disabled="editMode">
-            <i class="fa {{button.styleClass}}"></i>
+          <button type="button" class="nw-button {{button.styleClass}}" title="{{button.title}}" ng-click="execCommand(button.command)" ng-class="{ 'nw-button--active': isEditorActive() && button.isActive() }" ng-disabled="editMode">
+            {{ button.title }}
           </button>
         </div>
         <div ng-if="button.isComplex">
@@ -11,7 +11,9 @@
         </div>
     </li><!--
     --><li class="nw-toolbar__item">
-      <button type="button" class="nw-button nw-button--source" ng-class="{ 'nw-button--active': editMode }" ng-click="toggleEditMode()"><i class="fa fa-pencil"></i></button>
+      <button type="button" class="nw-button nw-button--source" ng-class="{ 'nw-button--active': editMode }" ng-click="toggleEditMode()">
+        Edit HTML
+      </button>
     </li>
   </ul>
 


### PR DESCRIPTION
Was auditioning this project for our software and saw an opportunity to "improve" consumer experience. Basically, if you move the font icon stuff to the stylesheet you can allow users to have different font icon sets and just update the CSS. This also removes the font awesome css from your required dependencies and improves accessibility (the buttons have text now instead of an _i_ tag).

If there's anything process-wise I missed let me know.