### PR TITLE
Disable editor

### DIFF
--- a/src/css/ng-wig.css
+++ b/src/css/ng-wig.css
@@ -140,7 +140,7 @@
   display: none;
 }
 
-.nw-editor:disabled {
+.nw-editor.nw-disabled {
 	cursor: default;
 }
 

--- a/src/css/ng-wig.css
+++ b/src/css/ng-wig.css
@@ -247,5 +247,9 @@
   border: 0;
 }
 
+.nw-select:disabled {
+	opacity: 0.5;
+}
+
 .nw-select:focus { outline: none; }
 

--- a/src/css/ng-wig.css
+++ b/src/css/ng-wig.css
@@ -140,6 +140,10 @@
   display: none;
 }
 
+.nw-editor:disabled {
+	cursor: default;
+}
+
 /**
  *  styling for toolbar button, has two modifiers: active and type of icon for background
  *

--- a/src/css/ng-wig.css
+++ b/src/css/ng-wig.css
@@ -217,6 +217,13 @@
   background-color: #EEEEEE;
 }
 
+.nw-button:disabled {
+  cursor: default;
+}
+.nw-button:disabled:hover {
+  opacity: 0.5;
+}
+
 /**
  *  styling & formatting of content inside contenteditable div
  *

--- a/src/index.html
+++ b/src/index.html
@@ -36,6 +36,9 @@
     <form name="myForm" novalidate>
         <textarea ng-wig="text2" on-paste="onPaste" buttons="formats, bold, italic" name="editor" required class="editor2 nw-editor--fixed"></textarea>
     </form>
+	
+    <h1>Disabled WYSIWYG</h1>
+    <textarea ng-wig="text3" on-paste="onPaste" class="editor1" source-mode-allowed ng-disabled="true"></textarea>
 
 </div>
 <script src="libs/angular/angular.js"></script>

--- a/src/javascript/app/ng-wig/ngWigDirective.js
+++ b/src/javascript/app/ng-wig/ngWigDirective.js
@@ -1,5 +1,5 @@
 angular.module('ngWig')
-  .directive('ngWig', function ($window, $document, $parse, ngWigToolbar) {
+  .directive('ngWig', function ($window, $document, ngWigToolbar) {
 
     return {
       scope: {
@@ -42,8 +42,8 @@ angular.module('ngWig')
           scope.$broadcast('execCommand', {command: command, options: options});
         };
 		
-		if (attrs.ngDisabled != null) {
-			scope.$watch(function() { return !!$parse(attrs.ngDisabled)(scope); }, function(isDisabled) {
+		if (attrs.ngDisabled != null || attrs.disabled != null) {
+			scope.$watch(function() { return !!attrs.disabled; }, function(isDisabled) {
 				scope.isDisabled = isDisabled;
 				scope.$broadcast('nw-disabled', isDisabled);
 			});	

--- a/src/javascript/app/ng-wig/ngWigDirective.js
+++ b/src/javascript/app/ng-wig/ngWigDirective.js
@@ -1,5 +1,5 @@
 angular.module('ngWig')
-  .directive('ngWig', function ($window, $document, ngWigToolbar) {
+  .directive('ngWig', function ($window, $document, $parse, ngWigToolbar) {
 
     return {
       scope: {
@@ -41,6 +41,10 @@ angular.module('ngWig')
           }
           scope.$broadcast('execCommand', {command: command, options: options});
         };
+		
+		scope.$watch(function() { return !!$parse(attrs.ngDisabled)(scope); }, function(isDisabled) {
+			scope.isDisabled = isDisabled;
+		});
       }
     }
   }

--- a/src/javascript/app/ng-wig/ngWigDirective.js
+++ b/src/javascript/app/ng-wig/ngWigDirective.js
@@ -45,6 +45,7 @@ angular.module('ngWig')
 		if (attrs.ngDisabled != null) {
 			scope.$watch(function() { return !!$parse(attrs.ngDisabled)(scope); }, function(isDisabled) {
 				scope.isDisabled = isDisabled;
+				scope.$broadcast('nw-disabled', isDisabled);
 			});	
 		}
       }

--- a/src/javascript/app/ng-wig/ngWigDirective.js
+++ b/src/javascript/app/ng-wig/ngWigDirective.js
@@ -42,9 +42,11 @@ angular.module('ngWig')
           scope.$broadcast('execCommand', {command: command, options: options});
         };
 		
-		scope.$watch(function() { return !!$parse(attrs.ngDisabled)(scope); }, function(isDisabled) {
-			scope.isDisabled = isDisabled;
-		});
+		if (attrs.ngDisabled != null) {
+			scope.$watch(function() { return !!$parse(attrs.ngDisabled)(scope); }, function(isDisabled) {
+				scope.isDisabled = isDisabled;
+			});	
+		}
       }
     }
   }

--- a/src/javascript/app/ng-wig/ngWigEditableDirective.js
+++ b/src/javascript/app/ng-wig/ngWigEditableDirective.js
@@ -65,6 +65,10 @@ angular.module('ngWig')
 
         viewToModel();
       });
+	  
+	  scope.$on('nw-disabled', function(event, isDisabled) {
+		  $element.attr('contenteditable', !isDisabled);
+	  });
     }
 
     return {

--- a/src/javascript/app/ng-wig/views/ng-wig.html
+++ b/src/javascript/app/ng-wig/views/ng-wig.html
@@ -22,7 +22,7 @@
       <textarea ng-required="isRequired" ng-disabled="isDisabled" class="nw-editor__src" ng-model="content"></textarea>
     </div>
     <div class="nw-editor">
-      <div name="{{formElementName}}" ng-required="isRequired" ng-disabled="isDisabled" tabindex="-1" ng-class="{'nw-invisible': editMode}" class="nw-editor__res" ng-model="content" ng-wig-editable on-paste="onPaste"></div>
+      <div name="{{formElementName}}" ng-required="isRequired" tabindex="-1" ng-class="{'nw-invisible': editMode}" class="nw-editor__res" ng-model="content" ng-wig-editable on-paste="onPaste"></div>
     </div>
   </div>
 </div>

--- a/src/javascript/app/ng-wig/views/ng-wig.html
+++ b/src/javascript/app/ng-wig/views/ng-wig.html
@@ -21,7 +21,7 @@
     <div class="nw-editor__src-container" ng-show="editMode">
       <textarea ng-required="isRequired" ng-disabled="isDisabled" class="nw-editor__src" ng-model="content"></textarea>
     </div>
-    <div class="nw-editor" ng-disabled="isDisabled">
+    <div class="nw-editor" ng-class="{ 'nw-disabled': isDisabled }">
       <div name="{{formElementName}}" ng-required="isRequired" tabindex="-1" ng-class="{'nw-invisible': editMode}" class="nw-editor__res" ng-model="content" ng-wig-editable on-paste="onPaste"></div>
     </div>
   </div>

--- a/src/javascript/app/ng-wig/views/ng-wig.html
+++ b/src/javascript/app/ng-wig/views/ng-wig.html
@@ -21,7 +21,7 @@
     <div class="nw-editor__src-container" ng-show="editMode">
       <textarea ng-required="isRequired" ng-disabled="isDisabled" class="nw-editor__src" ng-model="content"></textarea>
     </div>
-    <div class="nw-editor">
+    <div class="nw-editor" ng-disabled="isDisabled">
       <div name="{{formElementName}}" ng-required="isRequired" tabindex="-1" ng-class="{'nw-invisible': editMode}" class="nw-editor__res" ng-model="content" ng-wig-editable on-paste="onPaste"></div>
     </div>
   </div>

--- a/src/javascript/app/ng-wig/views/ng-wig.html
+++ b/src/javascript/app/ng-wig/views/ng-wig.html
@@ -19,10 +19,10 @@
 
   <div class="nw-editor-container">
     <div class="nw-editor__src-container" ng-show="editMode">
-      <textarea ng-required="isRequired" class="nw-editor__src" ng-model="content"></textarea>
+      <textarea ng-required="isRequired" ng-disabled="isDisabled" class="nw-editor__src" ng-model="content"></textarea>
     </div>
     <div class="nw-editor">
-      <div name="{{formElementName}}" ng-required="isRequired" tabindex="-1" ng-class="{'nw-invisible': editMode}" class="nw-editor__res" ng-model="content" ng-wig-editable on-paste="onPaste"></div>
+      <div name="{{formElementName}}" ng-required="isRequired" ng-disabled="isDisabled" tabindex="-1" ng-class="{'nw-invisible': editMode}" class="nw-editor__res" ng-model="content" ng-wig-editable on-paste="onPaste"></div>
     </div>
   </div>
 </div>

--- a/src/javascript/app/ng-wig/views/ng-wig.html
+++ b/src/javascript/app/ng-wig/views/ng-wig.html
@@ -2,7 +2,7 @@
   <ul class="nw-toolbar">
     <li class="nw-toolbar__item" ng-repeat="button in toolbarButtons" >
         <div ng-if="!button.isComplex">
-          <button type="button" class="nw-button {{button.styleClass}}" title="{{button.title}}" ng-click="execCommand(button.command)" ng-class="{ 'nw-button--active': isEditorActive() && button.isActive() }" ng-disabled="editMode">
+          <button type="button" class="nw-button {{button.styleClass}}" title="{{button.title}}" ng-click="execCommand(button.command)" ng-class="{ 'nw-button--active': isEditorActive() && button.isActive() }" ng-disabled="editMode || isDisabled">
             {{ button.title }}
           </button>
         </div>

--- a/src/javascript/app/ng-wig/views/ng-wig.html
+++ b/src/javascript/app/ng-wig/views/ng-wig.html
@@ -11,7 +11,7 @@
         </div>
     </li><!--
     --><li class="nw-toolbar__item">
-      <button type="button" class="nw-button nw-button--source" title="Edit HTML" ng-class="{ 'nw-button--active': editMode }" ng-show="isSourceModeAllowed" ng-click="toggleEditMode()">
+      <button type="button" class="nw-button nw-button--source" title="Edit HTML" ng-class="{ 'nw-button--active': editMode }" ng-show="isSourceModeAllowed" ng-click="toggleEditMode()" ng-disabled="isDisabled">
         Edit HTML
       </button>
     </li>

--- a/src/javascript/app/plugins/forecolor.ngWig.js
+++ b/src/javascript/app/plugins/forecolor.ngWig.js
@@ -6,7 +6,7 @@ angular.module('ngWig')
         return {
             restrict: 'E',
             replace: true,
-            template: '<button colorpicker ng-model="fontcolor" ng-disabled="editMode" colorpicker-position="right" class="nw-button font-color" title="Font Color">Font Color</button>',
+            template: '<button colorpicker ng-model="fontcolor" ng-disabled="editMode" colorpicker-position="right" class="nw-button font-color" title="Font Color" ng-disabled="isDisabled">Font Color</button>',
             link: function (scope) {
                 scope.$on('colorpicker-selected', function ($event, color) {
                     scope.execCommand('foreColor', color.value);

--- a/src/javascript/app/plugins/formats.ngWig.js
+++ b/src/javascript/app/plugins/formats.ngWig.js
@@ -6,7 +6,7 @@ angular.module('ngWig')
         return {
             restrict: 'E',
             replace: true,
-            template: '<select class="nw-select" ng-model="format" ng-change="execCommand(\'formatblock\', format.value)" ng-options="format.name for format in formats" ng-disabled="editMode"></select>',
+            template: '<select class="nw-select" ng-model="format" ng-change="execCommand(\'formatblock\', format.value)" ng-options="format.name for format in formats" ng-disabled="editMode || isDisabled"></select>',
             link: function (scope) {
                 scope.formats = [
                     {name: 'Normal text', value: 'p'},


### PR DESCRIPTION
Added the ability to set ng-disabled on the ng-wig element to disable the editor. The biggest difficulty here is that we have to set ng-disabled on every button element under the ng-wig, which means plugin authors will also have to support that. Otherwise it seems to work out pretty nicely and we can style against :disabled to remove the highlight. (In most cases - for the ng-wig-editable div we have to add a .nw-disabled class and style against that instead)

Issue https://github.com/stevermeister/ngWig/issues/95