### PR TITLE
Fix issue #117

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ or via bower:
     https://cdn.rawgit.com/stevermeister/ngWig/master/dist/css/ng-wig.css
 
 
-[Demo] (http://stevermeister.github.io/ngWig/demo/)  
+[Demo] (http://stevermeister.github.io/ngWig/demo/)
 
 [![Screenshot] (http://stevermeister.github.io/ngWig/images/ng-wig-demo.png)](http://stevermeister.github.io/ngWig/demo/)
 
@@ -44,40 +44,40 @@ or via bower:
 ##Examples
 
 ### Quick start ([plunker](https://plnkr.co/edit/IaTeHRUdWU1WUJnUiftl?p=preview))
-  ```<ng-wig ng-model="text1"></ng-wig>```    
-  
-###Disabled ([plunker](https://plnkr.co/edit/og1wRflbWfqyC8S4edzs?p=preview)) 
+  ```<ng-wig ng-model="text1"></ng-wig>```
+
+###Disabled ([plunker](https://plnkr.co/edit/og1wRflbWfqyC8S4edzs?p=preview))
 
   ```<ng-wig ng-model="text1" ng-disabled="true"></ng-wig>```
 
-###Edit Source option ([plunker](https://plnkr.co/edit/JVOI2l2gnZMKORMWjAEZ?p=preview)) 
+###Edit Source option ([plunker](https://plnkr.co/edit/JVOI2l2gnZMKORMWjAEZ?p=preview))
 
   ```<ng-wig ng-model="text1" source-mode-allowed></ng-wig>```
 
-###ngModel sync ([plunker](https://plnkr.co/edit/8owI0CDjoos8DArlc10g?p=preview))  
+###ngModel sync ([plunker](https://plnkr.co/edit/8owI0CDjoos8DArlc10g?p=preview))
 
   ```  <ng-wig ng-model="text1"></ng-wig>
-       <ng-wig ng-model="text1"></ng-wig>``` 
+       <ng-wig ng-model="text1"></ng-wig>```
 
-###Set buttons ([plunker](https://plnkr.co/edit/9Fjqwnf74jJAKNx2cMYI?p=preview))  
+###Set buttons ([plunker](https://plnkr.co/edit/9Fjqwnf74jJAKNx2cMYI?p=preview))
 
-  ```<ng-wig ng-model="text1" buttons="formats, bold, italic"></ng-wig>``` 
+  ```<ng-wig ng-model="text1" buttons="formats, bold, italic"></ng-wig>```
 
-###Setup generic buttons ([plunker](https://plnkr.co/edit/XteWPwo0eQ1gz4L6cpDr?p=preview))  
+###Setup generic buttons ([plunker](https://plnkr.co/edit/XteWPwo0eQ1gz4L6cpDr?p=preview))
 
     .config(['ngWigToolbarProvider', function(ngWigToolbarProvider) {
       ngWigToolbarProvider.setButtons(['bold', 'italic']);
     }]);
 
-###Add standard buttons ([plunker](https://plnkr.co/edit/Avi90RnnoTPGWzosQHQo?p=preview)) 
- 
+###Add standard buttons ([plunker](https://plnkr.co/edit/Avi90RnnoTPGWzosQHQo?p=preview))
+
     .config(['ngWigToolbarProvider', function(ngWigToolbarProvider) {
       ngWigToolbarProvider.addStandardButton('underline', 'Underline', 'underline', 'fa-underline');
     }]);
- 
-###Add custom buttons (plugin) ([plunker](https://plnkr.co/edit/vAKfMFRt9DAbUXSmUEFA?p=preview)) 
 
- 
+###Add custom buttons (plugin) ([plunker](https://plnkr.co/edit/vAKfMFRt9DAbUXSmUEFA?p=preview))
+
+
     angular.module('ngWig').config(['ngWigToolbarProvider', function(ngWigToolbarProvider) {
      ngWigToolbarProvider.addCustomButton('forecolor', 'nw-forecolor-button');
     }])
@@ -85,16 +85,16 @@ or via bower:
       template: '<button colorpicker ng-model="fontcolor" ng-disabled="editMode" colorpicker-position="right" class="nw-button font-color" title="Font Color" ng-disabled="isDisabled">Font Color</button>',
       controller: function($scope) {
         $scope.$on('colorpicker-selected', function($event, color) {
-          $scope.$broadcast('execCommand', {command: 'foreColor', options: color.value});
+          $scope.$emit('execCommand', {command: 'foreColor', options: color.value});
         });
       }
     });
- 
-###OnPaste Hook ([plunker](https://plnkr.co/edit/dsvfoDZw8CPVrNo9R6Bv?p=preview))  
 
-    ```<ng-wig ng-model="text1" on-paste="onPaste($event, pasteContent)"></ng-wig>```    
-    
-###Clear Styles button (plugin) ([plunker](https://plnkr.co/edit/j8FtcMAVkLSztZ6V0ION?p=preview)) 
+###OnPaste Hook ([plunker](https://plnkr.co/edit/dsvfoDZw8CPVrNo9R6Bv?p=preview))
+
+    ```<ng-wig ng-model="text1" on-paste="onPaste($event, pasteContent)"></ng-wig>```
+
+###Clear Styles button (plugin) ([plunker](https://plnkr.co/edit/j8FtcMAVkLSztZ6V0ION?p=preview))
 <br>
 <br>
 
@@ -102,6 +102,6 @@ or via bower:
 
     npm install
     npm run devSetup
-    
-    
+
+
 ## Creating plugins

--- a/src/javascript/app/ng-wig/ng-wig-plugin-adapter.component.js
+++ b/src/javascript/app/ng-wig/ng-wig-plugin-adapter.component.js
@@ -4,7 +4,8 @@ angular.module('ngWig')
       plugin: '<',
       execCommand: '=',
       editMode: '=',
-      disabled: '='
+      disabled: '=',
+      options: '<'
     },
     controller: function($scope, $element, $compile) {
       $element.replaceWith($compile('<' + this.plugin.pluginName + ' ' +
@@ -12,6 +13,7 @@ angular.module('ngWig')
         'exec-command=' + '"$ctrl.execCommand"' +
         'edit-mode=' + '"$ctrl.editMode"' +
         'disabled=' + '"$ctrl.disabled"' +
+        'options=' + '"$ctrl.options"' +
         '/>')($scope));
     }
   });

--- a/src/javascript/app/ng-wig/ng-wig.component.js
+++ b/src/javascript/app/ng-wig/ng-wig.component.js
@@ -4,7 +4,9 @@ angular.module('ngWig')
       content: '=ngModel',
       options: '<?',
       onPaste: '&',
-      buttons: '@'
+      buttons: '@',
+      beforeExecCommand: '&',
+      afterExecCommand: '&'
     },
     require: {
       ngModelController: 'ngModel'
@@ -40,7 +42,9 @@ angular.module('ngWig')
             return;
           }
         }
+        this.beforeExecCommand({command: command, options: options});
         $scope.$broadcast('execCommand', {command: command, options: options});
+        this.afterExecCommand({command: command, options: options});
       };
 
       this.$onInit = () => {

--- a/src/javascript/app/ng-wig/ng-wig.component.js
+++ b/src/javascript/app/ng-wig/ng-wig.component.js
@@ -59,7 +59,7 @@ angular.module('ngWig')
         }
 
         let pasteContent;
-        if (window.clipboardData && window.clipboardData.getData) { // IE  
+        if (window.clipboardData && window.clipboardData.getData) { // IE
           pasteContent = window.clipboardData.getData('Text');
         }
         else{
@@ -72,6 +72,7 @@ angular.module('ngWig')
       });
 
       $scope.$on('execCommand', (event, params) => {
+        event.stopPropagation();
         $container[0].focus();
 
         var ieStyleTextSelection = $document[0].selection,

--- a/src/javascript/app/ng-wig/ng-wig.component.js
+++ b/src/javascript/app/ng-wig/ng-wig.component.js
@@ -73,7 +73,7 @@ angular.module('ngWig')
       });
 
       $scope.$on('execCommand', (event, params) => {
-        event.stopPropagation();
+        event.stopPropagation && event.stopPropagation();
         $container[0].focus();
 
         var ieStyleTextSelection = $document[0].selection,

--- a/src/javascript/app/ng-wig/ng-wig.component.js
+++ b/src/javascript/app/ng-wig/ng-wig.component.js
@@ -2,6 +2,7 @@ angular.module('ngWig')
   .component('ngWig', {
     bindings: {
       content: '=ngModel',
+      options: '<?',
       onPaste: '&',
       buttons: '@'
     },

--- a/src/javascript/app/ng-wig/views/ng-wig.html
+++ b/src/javascript/app/ng-wig/views/ng-wig.html
@@ -16,7 +16,8 @@
               exec-command="$ctrl.execCommand"
               plugin="button"
               editMode="$ctrl.editMode"
-              disabled="$ctrl.disabled"></ng-wig-plugin>
+              disabled="$ctrl.disabled"
+              options="$ctrl.options"></ng-wig-plugin>
         </div>
     </li><!--
     --><li class="nw-toolbar__item">


### PR DESCRIPTION
1. Update readme to show correct example of custom button and stop
'execCommand' event propagation so that it does not go further up
the scope chain (when using emit).

Also, trailing whitespaces were removed by Sublime (not intended, but should not be an issue).

2. Add options object to enable more flexibility in creating plugins.

3. Fixes stopPropagation issue (a check is required to prevent errors when stopPropagation does not exists, for broadcast events). Alternatively, stopPropagation could be dropped altogether and execCommand method used instead of even emit/broadcast (readme must be updated accordingly).