### PR TITLE
Fixes for IE9+ in Formats plugin

### DIFF
--- a/src/javascript/app/ng-wig/ng-wig.component.js
+++ b/src/javascript/app/ng-wig/ng-wig.component.js
@@ -49,7 +49,7 @@ angular.module('ngWig')
 
       this.$onInit = () => {
         //model --> view
-        this.ngModelController.$render = () => $container.html(this.ngModelController.$viewValue || '');
+        this.ngModelController.$render = () => $container.html(this.ngModelController.$viewValue || '<p></p>');
 
         $container.bind('blur keyup change focus click', () => {
           //view --> model

--- a/src/javascript/app/plugins/formats.ngWig.js
+++ b/src/javascript/app/plugins/formats.ngWig.js
@@ -16,10 +16,10 @@ angular.module('ngWig')
         controller: function() {
 
             this.formats = [
-                {name: 'Normal text', value: 'p'},
-                {name: 'Header 1', value: 'h1'},
-                {name: 'Header 2', value: 'h2'},
-                {name: 'Header 3', value: 'h3'}
+                {name: 'Normal text', value: '<p>'},
+                {name: 'Header 1', value: '<h1>'},
+                {name: 'Header 2', value: '<h2>'},
+                {name: 'Header 3', value: '<h3>'}
             ];
 
             this.format = this.formats[0];


### PR DESCRIPTION
1. Text styles cannot be applied in IE9+.
2. Fixes #74 