### PR TITLE
createlink command in IE/Edge not working

### DIFF
--- a/src/javascript/app/ng-wig/ng-wig.component.js
+++ b/src/javascript/app/ng-wig/ng-wig.component.js
@@ -77,9 +77,9 @@ angular.module('ngWig')
       });
 
       $scope.$on('execCommand', (event, params) => {
-        var selection = $document[0].getSelection().toString();
-        var command = params.command;
-        var options = params.options;
+        let selection = $document[0].getSelection().toString();
+        let command = params.command;
+        let options = params.options;
 
         event.stopPropagation && event.stopPropagation();
 

--- a/src/javascript/app/ng-wig/ng-wig.component.js
+++ b/src/javascript/app/ng-wig/ng-wig.component.js
@@ -77,26 +77,24 @@ angular.module('ngWig')
       });
 
       $scope.$on('execCommand', (event, params) => {
+        var selection = $document[0].getSelection().toString();
+        var command = params.command;
+        var options = params.options;
+
         event.stopPropagation && event.stopPropagation();
+
         $container[0].focus();
-
-        var ieStyleTextSelection = $document[0].selection,
-          command = params.command,
-          options = params.options;
-
-        if (ieStyleTextSelection) {
-          var textRange = ieStyleTextSelection.createRange();
-        }
 
         if ($document[0].queryCommandSupported && !$document[0].queryCommandSupported(command)) {
           throw 'The command "' + command + '" is not supported';
         }
 
-        $document[0].execCommand(command, false, options);
-
-        if (ieStyleTextSelection) {
-          textRange.collapse(false);
-          textRange.select();
+        // use insertHtml for `createlink` command to account for IE/Edge purposes, in case there is no selection
+        if(command === 'createlink' && selection === ''){
+          $document[0].execCommand('insertHtml', false, '<a href="' + options + '">' + options + '</a>');
+        }
+        else{
+          $document[0].execCommand(command, false, options);
         }
       });
 


### PR DESCRIPTION
The command **createlink** is not working in IE/Edge when the user has not selected any text. 

My suggestion is to replace it with **insertHtml** command for that situation and add the link explicitly. I removed also IE style text selection detection using `$document[0].selection` since is now [deprecated](https://msdn.microsoft.com/en-us/library/ms535869(v=vs.85).aspx).