### PR TITLE
Added missing bindings to plugins. Fixed typo in main template.

### DIFF
--- a/src/javascript/app/ng-wig/views/ng-wig.html
+++ b/src/javascript/app/ng-wig/views/ng-wig.html
@@ -15,7 +15,7 @@
           <ng-wig-plugin
               exec-command="$ctrl.execCommand"
               plugin="button"
-              editMode="$ctrl.editMode"
+              edit-mode="$ctrl.editMode"
               disabled="$ctrl.disabled"
               options="$ctrl.options"
               content="$ctrl.content"></ng-wig-plugin>

--- a/src/javascript/app/plugins/clear-styles.ngWig.js
+++ b/src/javascript/app/plugins/clear-styles.ngWig.js
@@ -3,7 +3,11 @@ angular.module('ngWig')
     ngWigToolbarProvider.addCustomButton('clear-styles', 'nw-clear-styles-button');
   }])
   .component('nwClearStylesButton', {
-    template: '<button ng-click="$ctrl.clearStyles($event)" ng-disabled="editMode" class="nw-button clear-styles" title="Clear Styles" ng-disabled="isDisabled">Clear Styles</button>',
+    bindings: {
+      editMode: '=',
+      disabled: '='
+    },
+    template: '<button ng-click="$ctrl.clearStyles($event)" ng-disabled="$ctrl.editMode || $ctrl.disabled" class="nw-button clear-styles" title="Clear Styles">Clear Styles</button>',
     controller: function() {
       this.clearStyles = function(e){
           // find the ngWig element that hosts the plugin

--- a/src/javascript/app/plugins/forecolor.ngWig.js
+++ b/src/javascript/app/plugins/forecolor.ngWig.js
@@ -3,10 +3,17 @@ angular.module('ngWig')
     ngWigToolbarProvider.addCustomButton('forecolor', 'nw-forecolor-button');
   }])
   .component('nwForecolorButton', {
-    template: '<button colorpicker ng-model="fontcolor" ng-disabled="editMode" colorpicker-position="right" class="nw-button font-color" title="Font Color" ng-disabled="isDisabled">Font Color</button>',
+    bindings: {
+      execCommand: '=',
+      editMode: '=',
+      disabled: '='
+    },
+    template: '<button colorpicker ng-model="fontcolor" ng-disabled="$ctrl.editMode || $ctrl.disabled" colorpicker-position="right" class="nw-button font-color" title="Font Color">Font Color</button>',
     controller: function($scope) {
+      var ctrl = this;
+      
       $scope.$on('colorpicker-selected', function($event, color) {
-        $scope.execCommand('foreColor', color.value);
+        ctrl.execCommand('foreColor', color.value);
       });
     }
   });


### PR DESCRIPTION
- Added missing bindings to plugins so that they can be disabled/enabled according to the editor.
- `execCommand` was not working in the **Font Color** plugin because of missing binding.
- Fixed typo `editMode `to `edit-mode` in the main template file.