### PR TITLE
Replace execCommand broadcast with simple function

### DIFF
--- a/src/javascript/app/ng-wig/ng-wig.component.js
+++ b/src/javascript/app/ng-wig/ng-wig.component.js
@@ -45,7 +45,7 @@ angular.module('ngWig')
           }
         }
         this.beforeExecCommand({command: command, options: options});
-        $scope.$broadcast('execCommand', {command: command, options: options});
+        this.execute(command, options);
         this.afterExecCommand({command: command, options: options});
       };
 
@@ -79,12 +79,8 @@ angular.module('ngWig')
         });
       });
 
-      $scope.$on('execCommand', (event, params) => {
+      this.execute = (command, options) => {
         let selection = $document[0].getSelection().toString();
-        let command = params.command;
-        let options = params.options;
-
-        event.stopPropagation && event.stopPropagation();
 
         $container[0].focus();
 
@@ -99,7 +95,7 @@ angular.module('ngWig')
         else{
           $document[0].execCommand(command, false, options);
         }
-      });
+      };
 
     }
   });

--- a/src/javascript/app/ng-wig/ng-wig.component.spec.js
+++ b/src/javascript/app/ng-wig/ng-wig.component.spec.js
@@ -131,7 +131,7 @@ describe('component: ngWig', () => {
 
     describe('execCommand function', () => {
         beforeEach(() => {
-            spyOn(scope, '$broadcast');
+            spyOn(component, 'execute');
         });
 
         it('should exist', () => {
@@ -151,10 +151,7 @@ describe('component: ngWig', () => {
                 command: 'fakeCmd',
                 options: {}
             });
-            expect(scope.$broadcast).toHaveBeenCalledWith('execCommand', {
-                command: 'fakeCmd',
-                options: {}
-            });
+            expect(component.execute).toHaveBeenCalledWith('fakeCmd',{});
             expect(afterExecSpy).toHaveBeenCalledWith({
                 command: 'fakeCmd',
                 options: {}
@@ -187,7 +184,7 @@ describe('component: ngWig', () => {
             component.execCommand('createlink');
 
             expect(beforeExecSpy).not.toHaveBeenCalled();
-            expect(scope.$broadcast).not.toHaveBeenCalled();
+            expect(component.execute).not.toHaveBeenCalled();
             expect(afterExecSpy).not.toHaveBeenCalled();
         });
     });


### PR DESCRIPTION
I could not find any use of broadcasting the `execCommand` event inside the same scope (that of the **ngWig** component).