### PR TITLE
Fixes focus problems in toolbar and editor.

### DIFF
--- a/src/css/ng-wig.css
+++ b/src/css/ng-wig.css
@@ -261,6 +261,11 @@
 
 .nw-select:focus { outline: none; }
 
+.nw-button:focus {
+  border-color: lightgray;
+  border-style: solid;
+}
+
 [contenteditable]:empty:before {
   content: attr(placeholder);
   color: grey;

--- a/src/javascript/app/ng-wig/views/ng-wig.html
+++ b/src/javascript/app/ng-wig/views/ng-wig.html
@@ -42,7 +42,6 @@
     </div>
     <div class="nw-editor" ng-class="{ 'nw-disabled': $ctrl.disabled }">
       <div id="ng-wig-editable"
-           tabindex="-1"
            class="nw-editor__res"
            ng-class="{'nw-invisible': $ctrl.editMode}"
            ng-disabled="$ctrl.disabled"


### PR DESCRIPTION
Fixes #130, #113 partially. 

Added border to the toolbar buttons when they are focused. 

The `tabindex `in the `contenteditable `div was causing also trouble and the main editor area could not be focused. I have also tested it with multiple editors and works as expected.