### PR TITLE
Fix version number in global variable and CDN.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ or via bower:
 
 ##CDN
 
-    https://cdnjs.cloudflare.com/ajax/libs/ng-wig/3.0.7/ng-wig.min.js
+    https://cdnjs.cloudflare.com/ajax/libs/ng-wig/3.0.9/ng-wig.min.js
 
-    https://cdnjs.cloudflare.com/ajax/libs/ng-wig/3.0.7/ng-wig.js
+    https://cdnjs.cloudflare.com/ajax/libs/ng-wig/3.0.9/ng-wig.js
 
-    https://cdnjs.cloudflare.com/ajax/libs/ng-wig/3.0.7/css/ng-wig.css
+    https://cdnjs.cloudflare.com/ajax/libs/ng-wig/3.0.9/css/ng-wig.css
 
 ##Always last version CDN
     https://cdn.rawgit.com/stevermeister/ngWig/master/dist/ng-wig.min.js

--- a/src/javascript/app/ng-wig/ng-wig.js
+++ b/src/javascript/app/ng-wig/ng-wig.js
@@ -1,7 +1,7 @@
 /**
  * version: 3.0.9
  */
-var VERSION = '3.0.7';
+var VERSION = '3.0.9';
 angular.module('ngWig', ['ngwig-app-templates']);
 angular.ngWig = {
   version: VERSION


### PR DESCRIPTION
Set correct version number in global variable **angular.ngWig** and CDN links.