### PR TITLE
Fix disabled issue for IE

### DIFF
--- a/src/javascript/app/ng-wig/ng-wig-plugin-adapter.component.js
+++ b/src/javascript/app/ng-wig/ng-wig-plugin-adapter.component.js
@@ -15,7 +15,7 @@ angular.module('ngWig')
         'plugin=' + '"$ctrl.plugin"' +
         'exec-command=' + '"$ctrl.execCommand"' +
         'edit-mode=' + '"$ctrl.editMode"' +
-        'disabled=' + '"$ctrl.disabled"' +
+        'data-disabled=' + '"$ctrl.disabled"' +
         'options=' + '"$ctrl.options"' +
         'content=' + '"$ctrl.content"' +
         '/>')($scope));

--- a/src/javascript/app/ng-wig/ng-wig-plugin-adapter.component.spec.js
+++ b/src/javascript/app/ng-wig/ng-wig-plugin-adapter.component.spec.js
@@ -58,7 +58,7 @@ describe('component: ngWigPlugin', () => {
         'plugin=' + '"$ctrl.plugin"' +
         'exec-command=' + '"$ctrl.execCommand"' +
         'edit-mode=' + '"$ctrl.editMode"' +
-        'disabled=' + '"$ctrl.disabled"' +
+        'data-disabled=' + '"$ctrl.disabled"' +
         'options=' + '"$ctrl.options"' +
         'content=' + '"$ctrl.content"' +
         '/>')(scope);

--- a/src/javascript/app/ng-wig/views/ng-wig.html
+++ b/src/javascript/app/ng-wig/views/ng-wig.html
@@ -16,7 +16,7 @@
               exec-command="$ctrl.execCommand"
               plugin="button"
               edit-mode="$ctrl.editMode"
-              disabled="$ctrl.disabled"
+              data-disabled="$ctrl.disabled"
               options="$ctrl.options"
               content="$ctrl.content"></ng-wig-plugin>
         </div>


### PR DESCRIPTION
Add `data-` prefix to `disabled` attribute of plugin adapter so that it can be rendered in IE correctly.

fixes #178 resolves #132 