### PR TITLE
Use jsdelivr for last version CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ or via bower:
     https://cdnjs.cloudflare.com/ajax/libs/ng-wig/3.0.14/css/ng-wig.css
 
 ## Always last version CDN
-    https://cdn.rawgit.com/stevermeister/ngWig/master/dist/ng-wig.min.js
+    https://cdn.jsdelivr.net/gh/stevermeister/ngWig@master/dist/ng-wig.min.js
 
-    https://cdn.rawgit.com/stevermeister/ngWig/master/dist/ng-wig.js
+    https://cdn.jsdelivr.net/gh/stevermeister/ngWig@master/dist/ng-wig.js
 
-    https://cdn.rawgit.com/stevermeister/ngWig/master/dist/css/ng-wig.css
+    https://cdn.jsdelivr.net/gh/stevermeister/ngWig@master/dist/css/ng-wig.css
 
 
 [Demo] (http://stevermeister.github.io/ngWig/demo/)


### PR DESCRIPTION
Replace **RawGit** with **jsDelivr** because **RawGit** is going to shut down until October 2019 (more details here https://rawgit.com).

@stevermeister we should also check our demos in case we use RawGit there also.